### PR TITLE
remove test from prod script

### DIFF
--- a/.github/workflows/run_prod.yaml
+++ b/.github/workflows/run_prod.yaml
@@ -26,4 +26,4 @@ jobs:
       env: 'prod'
       schema-type: 'playerV3Versions'
       node-version: '18.x'
-      tests-yarn-run-to-execute: 'build lint:check types:check test'
+      tests-yarn-run-to-execute: 'build lint:check types:check'


### PR DESCRIPTION
### Description of the Changes

remove `test` from `tests-yarn-run-to-execute` in prod yaml file due to duplication.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
