### PR TITLE
fix(FEC-13892): slate plugin| KMS edit page "add/Cancel" presenters buttons appears one above each other instead of next to each other

### DIFF
--- a/cypress/e2e/slate.cy.ts
+++ b/cypress/e2e/slate.cy.ts
@@ -9,7 +9,7 @@ describe('Slate plugin', () => {
           message: 'Slate message'
         });
         cy.get('[data-testid="slate_root"]').should('exist');
-        cy.get('.slate-root .spinner-root').should('exist');
+        cy.get('[data-testid="spinner_container"]').should('exist');
         cy.get('[data-testid="slate_title"]').should('exist').should('have.text', 'Slate title');
         cy.get('[data-testid="slate_message"]').should('exist').should('have.text', 'Slate message');
         cy.get('[data-testid="slate_dismissButton"]').should('exist');
@@ -26,7 +26,7 @@ describe('Slate plugin', () => {
           showSpinner: false
         });
         cy.get('[data-testid="slate_root"]').should('exist');
-        cy.get('.slate-root .spinner-root').should('not.exist');
+        cy.get('[data-testid="spinner_container"]').should('not.exist');
       });
     });
 

--- a/cypress/e2e/slate.cy.ts
+++ b/cypress/e2e/slate.cy.ts
@@ -9,7 +9,7 @@ describe('Slate plugin', () => {
           message: 'Slate message'
         });
         cy.get('[data-testid="slate_root"]').should('exist');
-        cy.get('[data-testid="spinner_container"]').should('exist');
+        cy.get('[data-testid="slate_spinner_container"]').should('exist');
         cy.get('[data-testid="slate_title"]').should('exist').should('have.text', 'Slate title');
         cy.get('[data-testid="slate_message"]').should('exist').should('have.text', 'Slate message');
         cy.get('[data-testid="slate_dismissButton"]').should('exist');
@@ -26,7 +26,7 @@ describe('Slate plugin', () => {
           showSpinner: false
         });
         cy.get('[data-testid="slate_root"]').should('exist');
-        cy.get('[data-testid="spinner_container"]').should('not.exist');
+        cy.get('[data-testid="slate_spinner_container"]').should('not.exist');
       });
     });
 

--- a/src/components/slate/slate.tsx
+++ b/src/components/slate/slate.tsx
@@ -155,7 +155,7 @@ export class Slate extends Component<SlateProps> {
             <div className={styles.slateRoot} data-testid="slate_root">
               <div className={styles.slateContent} data-testid="slate_content">
                 {showSpinner ? (
-                  <div data-testid="spinner_container">
+                  <div data-testid="slate_spinner_container">
                     <Spinner size={this.getSpinnerSize()} />
                   </div>
                 ) : undefined}

--- a/src/components/slate/slate.tsx
+++ b/src/components/slate/slate.tsx
@@ -154,7 +154,11 @@ export class Slate extends Component<SlateProps> {
           <Overlay open onClose={onClose}>
             <div className={styles.slateRoot} data-testid="slate_root">
               <div className={styles.slateContent} data-testid="slate_content">
-                {showSpinner ? <Spinner size={this.getSpinnerSize()} /> : undefined}
+                {showSpinner ? (
+                  <div data-testid="spinner_container">
+                    <Spinner size={this.getSpinnerSize()} />
+                  </div>
+                ) : undefined}
                 {this.renderTextArea()}
                 {this.renderButtons()}
               </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = (env, { mode }) => {
               options: {
                 esModule: true,
                 modules: {
-                  localIdentName: '[local]',
+                  localIdentName: '[name]__[local]___[hash:base64:5]',                  
                   namedExport: true
                 }
               }


### PR DESCRIPTION
### Description of the Changes

Issue - Similar to https://github.com/kaltura/playkit-js-document-player/pull/7, unscoped css classes from common can cause issues if the embedding page contains an element with the same class

Fix - Add a scope prefix to the css classes of the plugin

Resolves FEC-13892

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
