### PR TITLE
fix(FEC-14873): Duplicate <style> tags appear on the page

### DIFF
--- a/.github/workflows/run_canary.yaml
+++ b/.github/workflows/run_canary.yaml
@@ -5,7 +5,7 @@ run-name: Canary
 on:
   push:
     branches:
-      - master
+      - test-webpack-externals-fix
 
 jobs:
   test:

--- a/.github/workflows/run_canary.yaml
+++ b/.github/workflows/run_canary.yaml
@@ -5,7 +5,7 @@ run-name: Canary
 on:
   push:
     branches:
-      - test-webpack-externals-fix
+      - master
 
 jobs:
   test:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ module.exports = (env, { mode }) => {
     },
     externals: {
       '@playkit-js/kaltura-player-js': 'root KalturaPlayer',
+      '@playkit-js/playkit-js': 'root KalturaPlayer.core',
       preact: 'root KalturaPlayer.ui.preact'
     },
     devServer: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = (env, { mode }) => {
               {
                 loader: 'style-loader',
                 options: {
+                  injectType: "singletonStyleTag",
                   attributes: {
                     id: `${packageData.name}`
                   },


### PR DESCRIPTION
### Description of the Changes

- Add @playkit-js/playkit-js as an external dependency to avoid having it added to the bundle, which creates a duplicat style tag
- Combine plugin style tags into a single tag

Resolves FEC-14873
